### PR TITLE
Remote schema validation via DecodoClient.create()

### DIFF
--- a/src/api/web-scraping-api.ts
+++ b/src/api/web-scraping-api.ts
@@ -1,7 +1,8 @@
 import { prettifyError } from 'zod';
 import { HttpClient } from '../http.js';
 import { ValidationError } from '../errors.js';
-import { requestSchemas } from '../generated/request-schemas.js';
+import { bundledSchemaProvider } from '../schema/bundled-provider.js';
+import type { SchemaProvider } from '../schema/types.js';
 import type { ScrapeRequest, BatchRequest } from '../generated/targets.js';
 import type {
   SyncResponse,
@@ -13,13 +14,15 @@ import type {
 
 export class WebScrapingApi {
   private readonly http: HttpClient;
+  private readonly schemas: SchemaProvider;
 
-  constructor(http: HttpClient) {
+  constructor(http: HttpClient, schemas: SchemaProvider = bundledSchemaProvider) {
     this.http = http;
+    this.schemas = schemas;
   }
 
   private validate(params: ScrapeRequest): void {
-    const schema = requestSchemas[params.target];
+    const schema = this.schemas.getRequestSchema(params.target);
     if (!schema) {
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,10 @@
 import { HttpClient } from './http.js';
 import { WebScrapingApi } from './api/web-scraping-api.js';
+import {
+  createSchemaProvider,
+  resolveSchemaProvider,
+} from './schema/resolve-provider.js';
+import type { SchemaProvider, ValidationConfig } from './schema/types.js';
 
 const WEB_API_BASE_URL = 'https://scraper-api.decodo.com';
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -9,7 +14,10 @@ export type DecodoConfig = {
     token: string;
   };
   timeoutMs?: number;
+  validation?: ValidationConfig;
 };
+
+export type { ValidationConfig };
 
 const notConfigured = (namespace: string, hint: string): never => {
   throw new Error(`${namespace} is not configured. ${hint}`);
@@ -18,8 +26,9 @@ const notConfigured = (namespace: string, hint: string): never => {
 export class DecodoClient {
   readonly webScrapingApi: WebScrapingApi;
 
-  constructor(config: DecodoConfig) {
+  constructor(config: DecodoConfig, schemaProvider?: SchemaProvider) {
     const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const provider = schemaProvider ?? resolveSchemaProvider(config.validation);
 
     if (config.webScrapingApi) {
       this.webScrapingApi = new WebScrapingApi(
@@ -31,6 +40,7 @@ export class DecodoClient {
           },
           timeoutMs,
         }),
+        provider,
       );
     } else {
       this.webScrapingApi = new Proxy({} as WebScrapingApi, {
@@ -42,5 +52,10 @@ export class DecodoClient {
         },
       });
     }
+  }
+
+  static async create(config: DecodoConfig): Promise<DecodoClient> {
+    const schemaProvider = await createSchemaProvider(config.validation);
+    return new DecodoClient(config, schemaProvider);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { DecodoClient } from './client.js';
-export type { DecodoConfig } from './client.js';
+export type { DecodoConfig, ValidationConfig } from './client.js';
 export { WebScrapingApi } from './api/web-scraping-api.js';
 
 export type {

--- a/src/schema/bundled-provider.ts
+++ b/src/schema/bundled-provider.ts
@@ -1,0 +1,9 @@
+import { requestSchemas } from '../generated/request-schemas.js';
+import { Target } from '../generated/targets.js';
+import type { SchemaProvider } from './types.js';
+
+export const bundledSchemaProvider: SchemaProvider = {
+  getRequestSchema(target: string) {
+    return requestSchemas[target as Target];
+  },
+};

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_IR_BUCKET = 'decodo-sdk-config';
+export const DEFAULT_IR_PREFIX = 'decodo-ir-v';
+export const DEFAULT_IR_BASE =
+  'https://storage.googleapis.com/decodo-sdk-config';
+export const DEFAULT_IR_LIST_URL =
+  'https://storage.googleapis.com/storage/v1/b/decodo-sdk-config/o?prefix=decodo-ir-v';
+export const DEFAULT_IR_CACHE_PATH = '~/.decodo/decodo.ir.json';

--- a/src/schema/expand-path.ts
+++ b/src/schema/expand-path.ts
@@ -1,0 +1,12 @@
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+export const expandPath = (path: string): string => {
+  if (path.startsWith('~/')) {
+    return resolve(homedir(), path.slice(2));
+  }
+  if (path === '~') {
+    return homedir();
+  }
+  return resolve(path);
+};

--- a/src/schema/remote-provider.ts
+++ b/src/schema/remote-provider.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import * as z from 'zod';
+import { DEFAULT_IR_CACHE_PATH } from './constants.js';
+import { expandPath } from './expand-path.js';
+import { resolveLatestIr } from './resolve-latest-ir.js';
+import type { SchemaProvider } from './types.js';
+
+type RemoteSchemaProviderConfig = {
+  url?: string;
+  cachePath?: string;
+  ttlMs?: number;
+};
+
+type RemoteIr = {
+  version: string;
+  apis: {
+    webScrapingApi: {
+      targets: Record<string, { parameter_schema: unknown }>;
+    };
+  };
+};
+
+type CachedIr = {
+  fetchedAt: number;
+  resolvedUrl: string;
+  ir: RemoteIr;
+};
+
+const readCachedIr = (cachePath: string): CachedIr | null => {
+  try {
+    const raw = readFileSync(cachePath, 'utf-8');
+    return JSON.parse(raw) as CachedIr;
+  } catch {
+    return null;
+  }
+};
+
+const isCacheFresh = (cached: CachedIr, ttlMs?: number): boolean => {
+  if (ttlMs === undefined) {
+    return true;
+  }
+  return Date.now() - cached.fetchedAt < ttlMs;
+};
+
+const fetchIr = async (url: string): Promise<RemoteIr> => {
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch IR from ${url}: HTTP ${res.status}`);
+  }
+
+  return (await res.json()) as RemoteIr;
+};
+
+const writeCachedIr = (cachePath: string, cached: CachedIr): void => {
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(cachePath, JSON.stringify(cached, null, 2));
+};
+
+const resolveIrUrl = async (
+  config: RemoteSchemaProviderConfig,
+): Promise<{ url: string; version?: string }> => {
+  if (config.url) {
+    return { url: config.url };
+  }
+
+  const latest = await resolveLatestIr();
+  return { url: latest.url, version: latest.version };
+};
+
+const loadIr = async (config: RemoteSchemaProviderConfig): Promise<RemoteIr> => {
+  const cachePath = expandPath(config.cachePath ?? DEFAULT_IR_CACHE_PATH);
+  const cached = readCachedIr(cachePath);
+
+  if (cached && isCacheFresh(cached, config.ttlMs)) {
+    return cached.ir;
+  }
+
+  const resolved = await resolveIrUrl(config);
+
+  if (cached) {
+    if (config.url) {
+      if (cached.resolvedUrl === config.url) {
+        return cached.ir;
+      }
+    } else if (resolved.version && cached.ir.version === resolved.version) {
+      return cached.ir;
+    }
+  }
+
+  const ir = await fetchIr(resolved.url);
+  writeCachedIr(cachePath, {
+    fetchedAt: Date.now(),
+    resolvedUrl: resolved.url,
+    ir,
+  });
+  return ir;
+};
+
+const buildRequestSchemas = (
+  ir: RemoteIr,
+): Map<string, z.ZodType> => {
+  const schemas = new Map<string, z.ZodType>();
+  const targets = ir.apis.webScrapingApi.targets;
+
+  for (const [targetKey, target] of Object.entries(targets)) {
+    schemas.set(
+      targetKey,
+      z.fromJSONSchema(
+        target.parameter_schema as z.core.JSONSchema.JSONSchema,
+      ),
+    );
+  }
+
+  return schemas;
+};
+
+export const createRemoteSchemaProvider = async (
+  config: RemoteSchemaProviderConfig = {},
+): Promise<SchemaProvider> => {
+  const ir = await loadIr(config);
+  const schemas = buildRequestSchemas(ir);
+
+  return {
+    getRequestSchema(target: string) {
+      return schemas.get(target);
+    },
+  };
+};

--- a/src/schema/resolve-latest-ir.ts
+++ b/src/schema/resolve-latest-ir.ts
@@ -1,0 +1,86 @@
+import {
+  DEFAULT_IR_BASE,
+  DEFAULT_IR_LIST_URL,
+  DEFAULT_IR_PREFIX,
+} from './constants.js';
+
+type GcsObjectList = {
+  items?: Array<{ name: string }>;
+};
+
+type LatestIrLocation = {
+  version: string;
+  url: string;
+};
+
+const IR_OBJECT_PATTERN = /^decodo-ir-v(.+)\.json$/;
+
+const parseSemver = (version: string): [number, number, number] | null => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    return null;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+const compareSemver = (left: string, right: string): number => {
+  const parsedLeft = parseSemver(left);
+  const parsedRight = parseSemver(right);
+
+  if (!parsedLeft || !parsedRight) {
+    return left.localeCompare(right);
+  }
+
+  for (let i = 0; i < 3; i += 1) {
+    if (parsedLeft[i] !== parsedRight[i]) {
+      return parsedLeft[i] - parsedRight[i];
+    }
+  }
+
+  return 0;
+};
+
+const parseIrVersions = (names: string[]): string[] => {
+  const versions: string[] = [];
+
+  for (const name of names) {
+    const match = IR_OBJECT_PATTERN.exec(name);
+    if (match && parseSemver(match[1])) {
+      versions.push(match[1]);
+    }
+  }
+
+  return versions;
+};
+
+export const resolveLatestIr = async (): Promise<LatestIrLocation> => {
+  const res = await fetch(DEFAULT_IR_LIST_URL, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to list IR versions from ${DEFAULT_IR_LIST_URL}: HTTP ${res.status}`,
+    );
+  }
+
+  const body = (await res.json()) as GcsObjectList;
+  const names = body.items?.map((item) => item.name) ?? [];
+  const versions = parseIrVersions(names);
+
+  if (versions.length === 0) {
+    throw new Error(
+      `No versioned IR objects found in bucket with prefix "${DEFAULT_IR_PREFIX}".`,
+    );
+  }
+
+  const version = versions.reduce((latest, current) =>
+    compareSemver(current, latest) > 0 ? current : latest,
+  );
+
+  return {
+    version,
+    url: `${DEFAULT_IR_BASE}/${DEFAULT_IR_PREFIX}${version}.json`,
+  };
+};

--- a/src/schema/resolve-provider.ts
+++ b/src/schema/resolve-provider.ts
@@ -1,0 +1,34 @@
+import { bundledSchemaProvider } from './bundled-provider.js';
+import { createRemoteSchemaProvider } from './remote-provider.js';
+import type { SchemaProvider, ValidationConfig } from './types.js';
+
+const REMOTE_VALIDATION_ERROR =
+  'Remote validation requires async initialization. Use DecodoClient.create() instead of new DecodoClient().';
+
+export const resolveSchemaProvider = (
+  validation?: ValidationConfig,
+): SchemaProvider => {
+  if (validation?.source === undefined || validation.source === 'bundled') {
+    return bundledSchemaProvider;
+  }
+
+  throw new Error(REMOTE_VALIDATION_ERROR);
+};
+
+export const createSchemaProvider = async (
+  validation?: ValidationConfig,
+): Promise<SchemaProvider> => {
+  if (validation?.source === undefined || validation.source === 'bundled') {
+    return bundledSchemaProvider;
+  }
+
+  if (validation.source === 'remote') {
+    return createRemoteSchemaProvider({
+      url: validation.url,
+      cachePath: validation.cachePath,
+      ttlMs: validation.ttlMs,
+    });
+  }
+
+  return bundledSchemaProvider;
+};

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod';
+
+export type SchemaProvider = {
+  getRequestSchema: (target: string) => z.ZodType | undefined;
+};

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,5 +1,9 @@
 import type { z } from 'zod';
 
+export type ValidationConfig =
+  | { source?: 'bundled' }
+  | { source: 'remote'; url?: string; cachePath?: string; ttlMs?: number };
+
 export type SchemaProvider = {
   getRequestSchema: (target: string) => z.ZodType | undefined;
 };


### PR DESCRIPTION
## Summary

Adds pluggable runtime validation to the SDK: bundled schemas remain the default, with an optional remote path that fetches the latest IR from GCS.

## API additions

- `ValidationConfig` on `DecodoConfig` (`source: 'bundled' | 'remote'`, optional `url`, `cachePath`, `ttlMs`)
- `DecodoClient.create()` — async client init for remote validation
- `new DecodoClient()` unchanged for existing apps; `source: 'remote'` on the sync constructor throws with a pointer to `create()`

Remote mode lists `decodo-sdk-config` on GCS, resolves the latest `decodo-ir-v*.json`, caches locally, and validates via compiled Zod schemas.

## Notes

- Internal `SchemaProvider` wiring in `WebScrapingApi` (bundled default)
- No breaking changes to existing `DecodoClient` usage
- Introspection and unit tests deferred 