### PR TITLE
Add configurable x-integration header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decodo/sdk-ts",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Official TypeScript SDK for the Decodo APIs",
   "type": "module",
   "main": "./build/cjs/index.cjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ const DEFAULT_TIMEOUT_MS = 180_000;
 export type DecodoConfig = {
   webScrapingApi?: {
     token: string;
+    integrationHeader?: string;
   };
   timeoutMs?: number;
   schema?: DecodoSchema;
@@ -34,6 +35,7 @@ export class DecodoClient {
             token: config.webScrapingApi.token,
           },
           timeoutMs,
+          integrationHeader: config.webScrapingApi.integrationHeader,
         }),
         schema,
       );

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HttpClient } from './http.js';
+import { jsonResponse, mockFetch } from './schema/test-helpers.js';
+
+const baseConfig = {
+  baseUrl: 'https://api.test',
+  auth: { type: 'basic' as const, token: 'test-token' },
+  timeoutMs: 5000,
+};
+
+describe('HttpClient integration header', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends x-integration: sdk-ts by default', async () => {
+    let capturedHeaders: Record<string, string> | undefined;
+
+    mockFetch((_input, init) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return jsonResponse({ ok: true });
+    });
+
+    const client = new HttpClient(baseConfig);
+    await client.get('/v3/task/1');
+
+    expect(capturedHeaders?.['x-integration']).toBe('sdk-ts');
+  });
+
+  it('sends a custom x-integration header when configured', async () => {
+    let capturedHeaders: Record<string, string> | undefined;
+
+    mockFetch((_input, init) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return jsonResponse({ ok: true });
+    });
+
+    const client = new HttpClient({
+      ...baseConfig,
+      integrationHeader: 'cli',
+    });
+    await client.get('/v3/task/1');
+
+    expect(capturedHeaders?.['x-integration']).toBe('cli');
+  });
+});

--- a/src/http.ts
+++ b/src/http.ts
@@ -21,16 +21,19 @@ export type HttpClientConfig = {
   baseUrl: string;
   auth: BasicAuth | ApiKeyAuth;
   timeoutMs: number;
+  integrationHeader?: string;
 };
 
 export class HttpClient {
   private readonly baseUrl: string;
   private readonly authHeader: string;
   private readonly timeoutMs: number;
+  private readonly integrationHeader: string;
 
   constructor(config: HttpClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/+$/, '');
     this.timeoutMs = config.timeoutMs;
+    this.integrationHeader = config.integrationHeader ?? 'sdk-ts';
 
     if (config.auth.type === 'basic') {
       this.authHeader = `Basic ${config.auth.token}`;
@@ -51,7 +54,7 @@ export class HttpClient {
           Authorization: this.authHeader,
           'Content-Type': 'application/json',
           Accept: 'application/json',
-          'x-integration': 'sdk-ts',
+          'x-integration': this.integrationHeader,
         },
         signal: controller.signal,
       };


### PR DESCRIPTION
## Summary
- Add optional `integrationHeader` to `DecodoClient` and `HttpClient` (defaults to `sdk-ts`)
- Bump version to `2.1.2` 
## Test plan
- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`