### PR TITLE
Add Gemini target from bundled IR v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Each target accepts one primary input parameter (`url`, `query`, `product_id`, o
 | --- | --- | --- |
 | `Target.Chatgpt` | ChatGPT response for a prompt | `{ target: Target.Chatgpt, prompt: "What are the top three dog breeds?" }` |
 | `Target.Perplexity` | Perplexity response for a prompt | `{ target: Target.Perplexity, prompt: "What causes seasonal allergies?" }` |
+| `Target.Gemini` | Gemini response for a prompt | `{ target: Target.Gemini, prompt: "What are the top three dog breeds?" }` |
 | `Target.GoogleAiMode` | Google AI Mode response | `{ target: Target.GoogleAiMode, query: "What are the top three dog breeds?" }` |
 
 ### Universal scraping

--- a/examples/web-scraping-api/gemini.ts
+++ b/examples/web-scraping-api/gemini.ts
@@ -1,0 +1,16 @@
+import { DecodoClient, Target } from '@decodo/sdk-ts';
+
+const client = new DecodoClient({
+  webScrapingApi: {
+    token: '<web_auth_token>',
+  },
+});
+
+const res = await client.webScrapingApi.scrape({
+  target: Target.Gemini,
+  prompt: 'What are the top three dog breeds?',
+  parse: true,
+  geo: 'United States',
+});
+
+console.log(JSON.stringify(res, null, 2));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decodo/sdk-ts",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Official TypeScript SDK for the Decodo APIs",
   "type": "module",
   "main": "./build/cjs/index.cjs",

--- a/src/generated/request-schemas.ts
+++ b/src/generated/request-schemas.ts
@@ -1514,6 +1514,34 @@ export const requestJsonSchemas = {
     ],
     "additionalProperties": false
   },
+  [Target.Gemini]: {
+    "type": "object",
+    "properties": {
+      "target": {
+        "const": "gemini"
+      },
+      "prompt": {
+        "type": "string",
+        "maxLength": 8192
+      },
+      "parse": {
+        "type": "boolean"
+      },
+      "geo": {
+        "type": "string"
+      },
+      "xhr": {
+        "type": "boolean"
+      },
+      "callback_url": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "target"
+    ],
+    "additionalProperties": false
+  },
   [Target.Bbb]: {
     "type": "object",
     "properties": {
@@ -2186,6 +2214,7 @@ export const requestSchemas: Record<Target, z.ZodType> = {
   [Target.Universal]: z.fromJSONSchema(requestJsonSchemas[Target.Universal] as unknown as z.core.JSONSchema.JSONSchema),
   [Target.Chatgpt]: z.fromJSONSchema(requestJsonSchemas[Target.Chatgpt] as unknown as z.core.JSONSchema.JSONSchema),
   [Target.Perplexity]: z.fromJSONSchema(requestJsonSchemas[Target.Perplexity] as unknown as z.core.JSONSchema.JSONSchema),
+  [Target.Gemini]: z.fromJSONSchema(requestJsonSchemas[Target.Gemini] as unknown as z.core.JSONSchema.JSONSchema),
   [Target.Bbb]: z.fromJSONSchema(requestJsonSchemas[Target.Bbb] as unknown as z.core.JSONSchema.JSONSchema),
   [Target.Autotrader]: z.fromJSONSchema(requestJsonSchemas[Target.Autotrader] as unknown as z.core.JSONSchema.JSONSchema),
   [Target.Mobile]: z.fromJSONSchema(requestJsonSchemas[Target.Mobile] as unknown as z.core.JSONSchema.JSONSchema),

--- a/src/generated/targets.ts
+++ b/src/generated/targets.ts
@@ -36,6 +36,7 @@ export enum Target {
   Universal = 'universal',
   Chatgpt = 'chatgpt',
   Perplexity = 'perplexity',
+  Gemini = 'gemini',
   Bbb = 'bbb',
   Autotrader = 'autotrader',
   Mobile = 'mobile',
@@ -60,7 +61,7 @@ export enum Target {
 /** API discriminator string literals (same values as {@link Target}). */
 export type TargetString = (typeof Target)[keyof typeof Target];
 
-export const targets = [Target.UniversalEcommerce, Target.GoogleSearch, Target.GoogleTravelHotels, Target.GoogleTrendsExplore, Target.GoogleShoppingSearch, Target.GoogleShoppingProduct, Target.Google, Target.GoogleSuggest, Target.GoogleMaps, Target.GoogleAiMode, Target.GoogleAds, Target.GoogleLens, Target.BingSearch, Target.Bing, Target.YoutubeTranscript, Target.AmazonProduct, Target.AmazonPricing, Target.AmazonSearch, Target.AmazonSellers, Target.AmazonBestsellers, Target.Amazon, Target.Ecommerce, Target.WalmartProduct, Target.WalmartSearch, Target.Walmart, Target.TargetProduct, Target.TargetSearch, Target.Target, Target.LowesSearch, Target.Universal, Target.Chatgpt, Target.Perplexity, Target.Bbb, Target.Autotrader, Target.Mobile, Target.Airbnb, Target.AppleAppStore, Target.InstagramGraphqlProfile, Target.TiktokPost, Target.TiktokShopSearch, Target.TiktokShopProduct, Target.Tiktok, Target.RedditPost, Target.RedditSubreddit, Target.RedditUser, Target.YoutubeVideo, Target.YoutubeMetadata, Target.YoutubeSearch, Target.YoutubeSearchMax, Target.YoutubeSubtitles, Target.YoutubeChannel] as const;
+export const targets = [Target.UniversalEcommerce, Target.GoogleSearch, Target.GoogleTravelHotels, Target.GoogleTrendsExplore, Target.GoogleShoppingSearch, Target.GoogleShoppingProduct, Target.Google, Target.GoogleSuggest, Target.GoogleMaps, Target.GoogleAiMode, Target.GoogleAds, Target.GoogleLens, Target.BingSearch, Target.Bing, Target.YoutubeTranscript, Target.AmazonProduct, Target.AmazonPricing, Target.AmazonSearch, Target.AmazonSellers, Target.AmazonBestsellers, Target.Amazon, Target.Ecommerce, Target.WalmartProduct, Target.WalmartSearch, Target.Walmart, Target.TargetProduct, Target.TargetSearch, Target.Target, Target.LowesSearch, Target.Universal, Target.Chatgpt, Target.Perplexity, Target.Gemini, Target.Bbb, Target.Autotrader, Target.Mobile, Target.Airbnb, Target.AppleAppStore, Target.InstagramGraphqlProfile, Target.TiktokPost, Target.TiktokShopSearch, Target.TiktokShopProduct, Target.Tiktok, Target.RedditPost, Target.RedditSubreddit, Target.RedditUser, Target.YoutubeVideo, Target.YoutubeMetadata, Target.YoutubeSearch, Target.YoutubeSearchMax, Target.YoutubeSubtitles, Target.YoutubeChannel] as const;
 
 export interface UniversalEcommerceParams {
   callback_url?: string;
@@ -482,6 +483,14 @@ export interface PerplexityParams {
   callback_url?: string;
 }
 
+export interface GeminiParams {
+  prompt?: string;
+  parse?: boolean;
+  geo?: string;
+  xhr?: boolean;
+  callback_url?: string;
+}
+
 export interface BbbParams {
   url?: string;
   headless?: 'html' | 'png';
@@ -691,6 +700,7 @@ export type TargetParamsMap = {
   [Target.Universal]: UniversalParams;
   [Target.Chatgpt]: ChatgptParams;
   [Target.Perplexity]: PerplexityParams;
+  [Target.Gemini]: GeminiParams;
   [Target.Bbb]: BbbParams;
   [Target.Autotrader]: AutotraderParams;
   [Target.Mobile]: MobileParams;
@@ -886,6 +896,11 @@ export const targetMeta: Record<Target, TargetMeta> = {
     group: "AI Tools",
     response_format: "json",
     parameters: ["prompt", "parse", "geo", "device_type", "markdown", "xhr", "callback_url"],
+  },
+  [Target.Gemini]: {
+    group: "AI Tools",
+    response_format: "json",
+    parameters: ["prompt", "parse", "geo", "xhr", "callback_url"],
   },
   [Target.Bbb]: {
     group: "Business Reviews",


### PR DESCRIPTION
## Summary
- Regenerate SDK from bundled Web Scraping API IR v2.1.1 (was v2.0.1).
- Adds the `gemini` target under AI Tools: enum/list entry, `GeminiParams`, target metadata, and JSON/Zod request schemas.

## Test plan
- [x] Run `pnpm typecheck` and confirm generated types compile.
- [x] Submit a request with `target: 'gemini'` and verify schema validation accepts `prompt`, `parse`, `geo`, `xhr`, and `callback_url`.